### PR TITLE
Update meta package xml to include zlib

### DIFF
--- a/point_cloud_transport_plugins/package.xml
+++ b/point_cloud_transport_plugins/package.xml
@@ -13,6 +13,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>draco_point_cloud_transport</exec_depend>
+  <exec_depend>point_cloud_interfaces</exec_depend>
+  <exec_depend>zlib_point_cloud_transport</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
zlib_point_cloud_transport plugin should be included in the meta package's package.xml