### PR TITLE
Add compression format field

### DIFF
--- a/draco_point_cloud_transport/src/draco_publisher.cpp
+++ b/draco_point_cloud_transport/src/draco_publisher.cpp
@@ -602,6 +602,7 @@ DracoPublisher::TypedEncodeResult DracoPublisher::encodeTyped(
   auto cast_buffer = reinterpret_cast<const unsigned char *>(encode_buffer.data());
   std::vector<unsigned char> vec_data(cast_buffer, cast_buffer + compressed_data_size);
   compressed.compressed_data = vec_data;
+  compressed.format = getTransportName();
 
   return compressed;
 }

--- a/point_cloud_interfaces/msg/CompressedPointCloud2.msg
+++ b/point_cloud_interfaces/msg/CompressedPointCloud2.msg
@@ -19,4 +19,4 @@ uint8[] compressed_data
 bool is_dense
 
 # compression format used (e.g. draco, zlib, etc.)
-bool format
+string format

--- a/point_cloud_interfaces/msg/CompressedPointCloud2.msg
+++ b/point_cloud_interfaces/msg/CompressedPointCloud2.msg
@@ -17,3 +17,6 @@ uint32 row_step
 uint8[] compressed_data
 
 bool is_dense
+
+# compression format used (e.g. draco, zlib, etc.)
+bool format

--- a/zlib_point_cloud_transport/src/zlib_publisher.cpp
+++ b/zlib_point_cloud_transport/src/zlib_publisher.cpp
@@ -81,6 +81,7 @@ ZlibPublisher::TypedEncodeResult ZlibPublisher::encodeTyped(
   compressed.is_dense = raw.is_dense;
   compressed.header = raw.header;
   compressed.fields = raw.fields;
+  compressed.format = getTransportName();
 
   return compressed;
 }


### PR DESCRIPTION
It seems like a good practice to indicate which compression was used to create a CompressedPointCloud2, since now zlib OR draco could be used for this.

This does not really matter for the subscriber or for rosbagging as those would have the transport label in the topic name, BUT i could see the case where someone has saved a CompressedPointCloud2 using a method other than rosbagging and wants to know the format.