### PR TITLE
Fixed crash due to already declared parameters

### DIFF
--- a/draco_point_cloud_transport/src/draco_subscriber.cpp
+++ b/draco_point_cloud_transport/src/draco_subscriber.cpp
@@ -47,11 +47,15 @@ namespace draco_point_cloud_transport
 {
 void DracoSubscriber::declareParameters()
 {
-  declareParam<bool>(std::string("SkipDequantizationPOSITION"), false);
-  declareParam<bool>(std::string("SkipDequantizationNORMAL"), false);
-  declareParam<bool>(std::string("SkipDequantizationCOLOR"), false);
-  declareParam<bool>(std::string("SkipDequantizationTEX_COORD"), false);
-  declareParam<bool>(std::string("SkipDequantizationGENERIC"), false);
+  try{
+    declareParam<bool>(std::string("SkipDequantizationPOSITION"), false);
+    declareParam<bool>(std::string("SkipDequantizationNORMAL"), false);
+    declareParam<bool>(std::string("SkipDequantizationCOLOR"), false);
+    declareParam<bool>(std::string("SkipDequantizationTEX_COORD"), false);
+    declareParam<bool>(std::string("SkipDequantizationGENERIC"), false);
+  } catch (rclcpp::exceptions::ParameterAlreadyDeclaredException & e) {
+    RCLCPP_DEBUG(this->getLogger(), e.what());
+  }
 
   auto param_change_callback =
     [this](std::vector<rclcpp::Parameter> parameters) -> rcl_interfaces::msg::SetParametersResult


### PR DESCRIPTION
When rviz2 is used with the current PR to display draco compressed point clouds (ros2/rviz#1008), rviz2 crashes when more than one draco subscriber is initialized, because the `SkipQuantization` parameters are already declared (as mentioned here: https://github.com/ros2/rviz/pull/1008#issuecomment-1804199022).

The crash can be reproduced by using the PR mentioned above and adding two PointCloud2 displays in rviz2 subscribing to topics ending on "/draco" (e.g. `/points1/draco` and `/points2/draco`). The pointclouds don't need to be published.

This PR adds a simple try-catch block around the `declare_parameters` statements to avoid the crash. 