### PR TITLE
[humble] Get user specified parameters at startup

### DIFF
--- a/draco_point_cloud_transport/src/draco_publisher.cpp
+++ b/draco_point_cloud_transport/src/draco_publisher.cpp
@@ -85,6 +85,7 @@ void DracoPublisher::declareParameters(const std::string & base_topic)
   declareParam<int>(
     encode_speed_paramDescriptor.name, config_.encode_speed,
     encode_speed_paramDescriptor);
+  getParam<int>(encode_speed_paramDescriptor.name, config_.encode_speed);
 
   rcl_interfaces::msg::ParameterDescriptor decode_speed_paramDescriptor;
   decode_speed_paramDescriptor.name = "decode_speed";
@@ -99,6 +100,7 @@ void DracoPublisher::declareParameters(const std::string & base_topic)
   declareParam<int>(
     decode_speed_paramDescriptor.name, config_.decode_speed,
     decode_speed_paramDescriptor);
+  getParam<int>(decode_speed_paramDescriptor.name, config_.decode_speed);
 
   rcl_interfaces::msg::ParameterDescriptor encode_method_paramDescriptor;
   encode_method_paramDescriptor.name = "encode_method";
@@ -113,6 +115,7 @@ void DracoPublisher::declareParameters(const std::string & base_topic)
   declareParam<int>(
     encode_method_paramDescriptor.name, config_.encode_method,
     encode_method_paramDescriptor);
+  getParam<int>(encode_method_paramDescriptor.name, config_.encode_method);
 
   rcl_interfaces::msg::ParameterDescriptor deduplicate_paramDescriptor;
   deduplicate_paramDescriptor.name = "deduplicate";
@@ -120,6 +123,7 @@ void DracoPublisher::declareParameters(const std::string & base_topic)
   deduplicate_paramDescriptor.description =
     "Remove duplicate point entries.";
   declareParam<bool>(deduplicate_paramDescriptor.name, true, deduplicate_paramDescriptor);
+  getParam<bool>(deduplicate_paramDescriptor.name, config_.deduplicate);
 
   rcl_interfaces::msg::ParameterDescriptor force_quantization_paramDescriptor;
   force_quantization_paramDescriptor.name = "force_quantization";
@@ -130,6 +134,7 @@ void DracoPublisher::declareParameters(const std::string & base_topic)
   declareParam<bool>(
     force_quantization_paramDescriptor.name, config_.force_quantization,
     force_quantization_paramDescriptor);
+  getParam<bool>(force_quantization_paramDescriptor.name, config_.force_quantization);
 
   rcl_interfaces::msg::ParameterDescriptor quantization_POSITION_paramDescriptor;
   quantization_POSITION_paramDescriptor.name = "quantization_POSITION";
@@ -143,8 +148,9 @@ void DracoPublisher::declareParameters(const std::string & base_topic)
       .set__to_value(31)
       .set__step(1)});
   declareParam<int>(
-    quantization_POSITION_paramDescriptor.name, config_.quantization_NORMAL,
+    quantization_POSITION_paramDescriptor.name, config_.quantization_POSITION,
     quantization_POSITION_paramDescriptor);
+  getParam<int>(quantization_POSITION_paramDescriptor.name, config_.quantization_POSITION);
 
   rcl_interfaces::msg::ParameterDescriptor quantization_NORMAL_paramDescriptor;
   quantization_NORMAL_paramDescriptor.name = "quantization_NORMAL";
@@ -157,8 +163,9 @@ void DracoPublisher::declareParameters(const std::string & base_topic)
       .set__to_value(31)
       .set__step(1)});
   declareParam<int>(
-    quantization_NORMAL_paramDescriptor.name, config_.quantization_COLOR,
+    quantization_NORMAL_paramDescriptor.name, config_.quantization_NORMAL,
     quantization_NORMAL_paramDescriptor);
+  getParam<int>(quantization_NORMAL_paramDescriptor.name, config_.quantization_NORMAL);
 
   rcl_interfaces::msg::ParameterDescriptor quantization_COLOR_paramDescriptor;
   quantization_COLOR_paramDescriptor.name = "quantization_COLOR";
@@ -171,8 +178,9 @@ void DracoPublisher::declareParameters(const std::string & base_topic)
       .set__to_value(31)
       .set__step(1)});
   declareParam<int>(
-    quantization_COLOR_paramDescriptor.name, config_.quantization_TEX_COORD,
+    quantization_COLOR_paramDescriptor.name, config_.quantization_COLOR,
     quantization_COLOR_paramDescriptor);
+  getParam<int>(quantization_COLOR_paramDescriptor.name, config_.quantization_COLOR);
 
   rcl_interfaces::msg::ParameterDescriptor quantization_TEX_COORD_paramDescriptor;
   quantization_TEX_COORD_paramDescriptor.name = "quantization_TEX_COORD";
@@ -186,8 +194,9 @@ void DracoPublisher::declareParameters(const std::string & base_topic)
       .set__to_value(31)
       .set__step(1)});
   declareParam<int>(
-    quantization_TEX_COORD_paramDescriptor.name, config_.quantization_GENERIC,
+    quantization_TEX_COORD_paramDescriptor.name, config_.quantization_TEX_COORD,
     quantization_TEX_COORD_paramDescriptor);
+  getParam<int>(quantization_TEX_COORD_paramDescriptor.name, config_.quantization_TEX_COORD);
 
   rcl_interfaces::msg::ParameterDescriptor quantization_GENERIC_paramDescriptor;
   quantization_GENERIC_paramDescriptor.name = "quantization_GENERIC";
@@ -201,8 +210,9 @@ void DracoPublisher::declareParameters(const std::string & base_topic)
       .set__to_value(31)
       .set__step(1)});
   declareParam<int>(
-    quantization_GENERIC_paramDescriptor.name, config_.quantization_POSITION,
+    quantization_GENERIC_paramDescriptor.name, config_.quantization_GENERIC,
     quantization_GENERIC_paramDescriptor);
+  getParam<int>(quantization_GENERIC_paramDescriptor.name, config_.quantization_GENERIC);
 
   rcl_interfaces::msg::ParameterDescriptor expert_quantization_paramDescriptor;
   expert_quantization_paramDescriptor.name = "expert_quantization";
@@ -214,6 +224,7 @@ void DracoPublisher::declareParameters(const std::string & base_topic)
   declareParam<bool>(
     expert_quantization_paramDescriptor.name, config_.expert_quantization,
     expert_quantization_paramDescriptor);
+  getParam<bool>(expert_quantization_paramDescriptor.name, config_.expert_quantization);
 
   rcl_interfaces::msg::ParameterDescriptor expert_attribute_types_paramDescriptor;
   expert_attribute_types_paramDescriptor.name = "expert_attribute_types";
@@ -225,7 +236,9 @@ void DracoPublisher::declareParameters(const std::string & base_topic)
   declareParam<bool>(
     expert_attribute_types_paramDescriptor.name, config_.expert_attribute_types,
     expert_attribute_types_paramDescriptor);
+  getParam<bool>(expert_attribute_types_paramDescriptor.name, config_.expert_attribute_types);
 
+  // we call get param at runtime to get the latest value for these
   declareParam<std::string>("attribute_mapping.attribute_type.x", "POSITION");
   declareParam<std::string>("attribute_mapping.attribute_type.y", "POSITION");
   declareParam<std::string>("attribute_mapping.attribute_type.z", "POSITION");

--- a/draco_point_cloud_transport/src/draco_subscriber.cpp
+++ b/draco_point_cloud_transport/src/draco_subscriber.cpp
@@ -48,10 +48,15 @@ namespace draco_point_cloud_transport
 void DracoSubscriber::declareParameters()
 {
   declareParam<bool>(std::string("SkipDequantizationPOSITION"), false);
+  getParam<bool>(std::string("SkipDequantizationPOSITION"), config_.SkipDequantizationPOSITION);
   declareParam<bool>(std::string("SkipDequantizationNORMAL"), false);
+  getParam<bool>(std::string("SkipDequantizationNORMAL"), config_.SkipDequantizationNORMAL);
   declareParam<bool>(std::string("SkipDequantizationCOLOR"), false);
+  getParam<bool>(std::string("SkipDequantizationCOLOR"), config_.SkipDequantizationCOLOR);
   declareParam<bool>(std::string("SkipDequantizationTEX_COORD"), false);
+  getParam<bool>(std::string("SkipDequantizationTEX_COORD"), config_.SkipDequantizationTEX_COORD);
   declareParam<bool>(std::string("SkipDequantizationGENERIC"), false);
+  getParam<bool>(std::string("SkipDequantizationGENERIC"), config_.SkipDequantizationGENERIC);
 
   auto param_change_callback =
     [this](std::vector<rclcpp::Parameter> parameters) -> rcl_interfaces::msg::SetParametersResult

--- a/zlib_point_cloud_transport/src/zlib_publisher.cpp
+++ b/zlib_point_cloud_transport/src/zlib_publisher.cpp
@@ -54,6 +54,7 @@ void ZlibPublisher::declareParameters(const std::string & base_topic)
   declareParam<int>(
     encode_level_paramDescriptor.name, this->encode_level_,
     encode_level_paramDescriptor);
+  getParam<int>(encode_level_paramDescriptor.name, this->encode_level_);
 
   auto param_change_callback =
     [this](const std::vector<rclcpp::Parameter> & parameters) -> rcl_interfaces::msg::

--- a/zstd_point_cloud_transport/src/zstd_publisher.cpp
+++ b/zstd_point_cloud_transport/src/zstd_publisher.cpp
@@ -58,6 +58,7 @@ void ZstdPublisher::declareParameters(const std::string & base_topic)
   declareParam<int>(
     encode_level_paramDescriptor.name, this->encode_level_,
     encode_level_paramDescriptor);
+  getParam<int>(encode_level_paramDescriptor.name, this->encode_level_);
 
   auto param_change_callback =
     [this](const std::vector<rclcpp::Parameter> & parameters) -> rcl_interfaces::msg::


### PR DESCRIPTION
Currently, no plugins that `declare` parameters `get` the values at startup. This means that even if a user were to specify a parameter via ros2 launch or ros2 run, it would not get loaded. The only way to load a non-default parameter atm is to dynamically configure it after startup.

This PR fixes this by `get`ting the parameter values at startup. For users who are currently using the default values, this PR does nothing. For users who want to be able to specify the parameters at startup, this will allow them to do that.

Relates to this issue: https://github.com/ros-perception/point_cloud_transport/issues/66