### PR TITLE
Fix linking to draco if DRACO_LIBRARIES is not defined

### DIFF
--- a/draco_point_cloud_transport/CMakeLists.txt
+++ b/draco_point_cloud_transport/CMakeLists.txt
@@ -36,9 +36,26 @@ add_library(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  ${DRACO_LIBRARIES}
   ${dependencies}
 )
+
+# draco 1.5.3 dropped the DRACO_LIBRARIES variable in favor of
+# draco::draco imported target, but debian introduced DRACO_LIBRARIES
+# back, but that is not present in other distributions. For maximum
+# compatibility, we link DRACO_LIBRARIES if defined, otherwise draco::draco
+# See:
+# * https://github.com/google/draco/commit/7109fbee87c6d932cdc0ac7394bc5d485db26d44
+# * https://sources.debian.org/patches/draco/1.5.6+dfsg-3/0004-Set-DRACO_LIBRARIES-for-backwards-compatibility.patch/
+if(DEFINED DRACO_LIBRARIES)
+  target_link_libraries(${PROJECT_NAME} PRIVATE
+    ${DRACO_LIBRARIES}
+  )
+else()
+  target_link_libraries(${PROJECT_NAME} PRIVATE
+    draco::draco
+  )
+endif()
+
 target_include_directories(${PROJECT_NAME} PRIVATE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"


### PR DESCRIPTION
https://github.com/ros-perception/point_cloud_transport_plugins/pull/57 switched to linking `DRACO_LIBRARIES` from `DRACO_LIBRARY`, but the upstream project does not define any `DRACO_LIBRARIES` CMake variable, see https://github.com/google/draco/commit/7109fbee87c6d932cdc0ac7394bc5d485db26d44, while the `DRACO_LIBRARIES` is added as a patch by Debian distributions (see https://sources.debian.org/patches/draco/1.5.6+dfsg-3/0004-Set-DRACO_LIBRARIES-for-backwards-compatibility.patch/). 

To fix compat with non-Debian distribution, we link to `DRACO_LIBRARIES` if defined, or `draco::draco` otherwise.

xref: https://github.com/ros-perception/point_cloud_transport_plugins/pull/66