### PR TITLE
Correctly export dependencies for downstream packages

### DIFF
--- a/draco_point_cloud_transport/CMakeLists.txt
+++ b/draco_point_cloud_transport/CMakeLists.txt
@@ -16,13 +16,13 @@ find_package(std_msgs REQUIRED)
 find_package(Draco REQUIRED)
 
 set(dependencies
-  pluginlib::pluginlib
-  ${point_cloud_interfaces_TARGETS}
-  point_cloud_transport::point_cloud_transport
-  rclcpp::rclcpp
-  rcpputils::rcpputils
-  ${sensor_msgs_TARGETS}
-  ${std_msgs_TARGETS}
+  pluginlib
+  point_cloud_interfaces
+  point_cloud_transport
+  rclcpp
+  rcpputils
+  sensor_msgs
+  std_msgs
 )
 
 include_directories(include)
@@ -36,7 +36,13 @@ add_library(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  ${dependencies}
+  pluginlib::pluginlib
+  ${point_cloud_interfaces_TARGETS}
+  point_cloud_transport::point_cloud_transport
+  rclcpp::rclcpp
+  rcpputils::rcpputils
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
 )
 
 # draco 1.5.3 dropped the DRACO_LIBRARIES variable in favor of

--- a/plugin_template/CMakeLists.txt
+++ b/plugin_template/CMakeLists.txt
@@ -15,10 +15,10 @@ find_package(rclcpp REQUIRED)
 # TODO (YourNameHere): You might need more dependencies
 
 set(dependencies
-  pluginlib::pluginlib
-  ${point_cloud_interfaces_TARGETS}
-  point_cloud_transport::point_cloud_transport
-  rclcpp::rclcpp
+  pluginlib
+  point_cloud_interfaces
+  point_cloud_transport
+  rclcpp
 )
 
 target_include_directories(${PROJECT_NAME} PRIVATE
@@ -34,7 +34,10 @@ add_library(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  ${dependencies}
+  pluginlib::pluginlib
+  ${point_cloud_interfaces_TARGETS}
+  point_cloud_transport::point_cloud_transport
+  rclcpp::rclcpp
 )
 
 install(TARGETS ${PROJECT_NAME}

--- a/zlib_point_cloud_transport/CMakeLists.txt
+++ b/zlib_point_cloud_transport/CMakeLists.txt
@@ -12,10 +12,10 @@ find_package(rclcpp REQUIRED)
 find_package(ZLIB REQUIRED)
 
 set(dependencies
-  pluginlib::pluginlib
-  ${point_cloud_interfaces_TARGETS}
-  point_cloud_transport::point_cloud_transport
-  rclcpp::rclcpp
+  pluginlib
+  point_cloud_interfaces
+  point_cloud_transport
+  rclcpp
 )
 
 add_library(${PROJECT_NAME}
@@ -27,9 +27,13 @@ add_library(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
+  pluginlib::pluginlib
+  ${point_cloud_interfaces_TARGETS}
+  point_cloud_transport::point_cloud_transport
+  rclcpp::rclcpp
   ZLIB::ZLIB
-  ${dependencies}
 )
+
 target_include_directories(${PROJECT_NAME} PRIVATE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"

--- a/zstd_point_cloud_transport/CMakeLists.txt
+++ b/zstd_point_cloud_transport/CMakeLists.txt
@@ -11,10 +11,10 @@ find_package(point_cloud_transport REQUIRED)
 find_package(rclcpp REQUIRED)
 
 set(dependencies
-  pluginlib::pluginlib
-  ${point_cloud_interfaces_TARGETS}
-  point_cloud_transport::point_cloud_transport
-  rclcpp::rclcpp
+  pluginlib
+  point_cloud_interfaces
+  point_cloud_transport
+  rclcpp
 )
 
 add_library(${PROJECT_NAME}
@@ -25,8 +25,11 @@ add_library(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
+  pluginlib::pluginlib
+  ${point_cloud_interfaces_TARGETS}
+  point_cloud_transport::point_cloud_transport
+  rclcpp::rclcpp
   zstd
-  ${dependencies}
 )
 
 target_include_directories(${PROJECT_NAME} PRIVATE


### PR DESCRIPTION
This PR addresses #69.

Commit bb3c126 should be backported/cherry-picked for `humble` and `jazzy` branches.