### PR TITLE
Explicitly find zstd and remove undefined function 

### DIFF
--- a/zstd_point_cloud_transport/CMakeLists.txt
+++ b/zstd_point_cloud_transport/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(pluginlib REQUIRED)
 find_package(point_cloud_interfaces REQUIRED)
 find_package(point_cloud_transport REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(zstd_cmake_module REQUIRED)
+find_package(zstd REQUIRED)
 
 set(dependencies
   pluginlib
@@ -29,7 +31,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   ${point_cloud_interfaces_TARGETS}
   point_cloud_transport::point_cloud_transport
   rclcpp::rclcpp
-  zstd
+  zstd::zstd
 )
 
 target_include_directories(${PROJECT_NAME} PRIVATE

--- a/zstd_point_cloud_transport/CMakeLists.txt
+++ b/zstd_point_cloud_transport/CMakeLists.txt
@@ -17,6 +17,8 @@ set(dependencies
   point_cloud_interfaces
   point_cloud_transport
   rclcpp
+  zstd_cmake_module
+  zstd
 )
 
 add_library(${PROJECT_NAME}

--- a/zstd_point_cloud_transport/CMakeLists.txt
+++ b/zstd_point_cloud_transport/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(pluginlib REQUIRED)
 find_package(point_cloud_interfaces REQUIRED)
 find_package(point_cloud_transport REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(Zstd REQUIRED)
 
 set(dependencies
   pluginlib
@@ -30,7 +29,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   ${point_cloud_interfaces_TARGETS}
   point_cloud_transport::point_cloud_transport
   rclcpp::rclcpp
-  zstd::libzstd_shared
+  zstd
 )
 
 target_include_directories(${PROJECT_NAME} PRIVATE

--- a/zstd_point_cloud_transport/CMakeLists.txt
+++ b/zstd_point_cloud_transport/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(pluginlib REQUIRED)
 find_package(point_cloud_interfaces REQUIRED)
 find_package(point_cloud_transport REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(Zstd REQUIRED)
 
 set(dependencies
   pluginlib
@@ -29,7 +30,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   ${point_cloud_interfaces_TARGETS}
   point_cloud_transport::point_cloud_transport
   rclcpp::rclcpp
-  zstd
+  zstd::libzstd_shared
 )
 
 target_include_directories(${PROJECT_NAME} PRIVATE

--- a/zstd_point_cloud_transport/include/zstd_point_cloud_transport/zstd_subscriber.hpp
+++ b/zstd_point_cloud_transport/include/zstd_point_cloud_transport/zstd_subscriber.hpp
@@ -51,8 +51,6 @@ class ZstdSubscriber
 public:
   ZstdSubscriber();
 
-  std::string getTransportName() const override;
-
   void declareParameters() override;
 
   std::string getDataType() const override;

--- a/zstd_point_cloud_transport/package.xml
+++ b/zstd_point_cloud_transport/package.xml
@@ -22,7 +22,7 @@
   <depend>point_cloud_interfaces</depend>
   <depend>point_cloud_transport</depend>
   <depend>rclcpp</depend>
-  <depend>libzstd-dev</depend>
+  <depend>zstd_cmake_module</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
```
--- stderr: zstd_point_cloud_transport
Undefined symbols for architecture arm64:
  "vtable for zstd_point_cloud_transport::ZstdSubscriber", referenced from:
      zstd_point_cloud_transport::ZstdSubscriber::ZstdSubscriber() in zstd_subscriber.cpp.o
   NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [libzstd_point_cloud_transport.dylib] Error 1
make[1]: *** [CMakeFiles/zstd_point_cloud_transport.dir/all] Error 2
make: *** [all] Error 2
---
Failed   <<< zstd_point_cloud_transport [1.27s, exited with code 2]
```

Probably related to https://github.com/ros-perception/point_cloud_transport_plugins/pull/79

cc @ahcorde 