### PR TITLE
Replace undefined behaviour &vector[0] with data() and cleanups

### DIFF
--- a/draco_point_cloud_transport/src/draco_publisher.cpp
+++ b/draco_point_cloud_transport/src/draco_publisher.cpp
@@ -445,7 +445,7 @@ tl::expected<std::unique_ptr<draco::PointCloud>, std::string> DracoPublisher::co
     // Set attribute values for the last added attribute
     if ((!att_ids.empty()) && (attribute_data_type != draco::DT_INVALID)) {
       builder.SetAttributeValuesForAllPoints(
-        static_cast<int>(att_ids.back()), &PC2.data[0] + field.offset, PC2.point_step);
+        static_cast<int>(att_ids.back()), PC2.data.data() + field.offset, PC2.point_step);
     }
   }
   // finalize point cloud *** builder.Finalize(bool deduplicate) ***
@@ -611,8 +611,7 @@ DracoPublisher::TypedEncodeResult DracoPublisher::encodeTyped(
 
   uint32_t compressed_data_size = static_cast<uint32_t>(encode_buffer.size());
   auto cast_buffer = reinterpret_cast<const unsigned char *>(encode_buffer.data());
-  std::vector<unsigned char> vec_data(cast_buffer, cast_buffer + compressed_data_size);
-  compressed.compressed_data = vec_data;
+  compressed.compressed_data.assign(cast_buffer, cast_buffer + compressed_data_size);
   compressed.format = getTransportName();
 
   return compressed;

--- a/draco_point_cloud_transport/src/draco_subscriber.cpp
+++ b/draco_point_cloud_transport/src/draco_subscriber.cpp
@@ -97,6 +97,14 @@ tl::expected<bool, std::string> convertDracoToPC2(
   // number of all attributes of point cloud
   int32_t number_of_attributes = pc.num_attributes();
 
+  // The loop below indexes compressed_PC2.fields[att_id] for every attribute,
+  // so the decoded cloud must not advertise more attributes than the message
+  // has fields, otherwise we would read out of bounds.
+  if (static_cast<size_t>(number_of_attributes) > compressed_PC2.fields.size()) {
+    return tl::make_unexpected(
+      "Decoded Draco point cloud has more attributes than the message has fields.");
+  }
+
   // number of points in pointcloud
   draco::PointIndex::ValueType number_of_points = pc.num_points();
 
@@ -148,12 +156,13 @@ DracoSubscriber::DecodeResult DracoSubscriber::decodeTyped(
   }
 
   draco::DecoderBuffer decode_buffer;
-  std::vector<unsigned char> vec_data = compressed.compressed_data;
 
   // Sets the buffer's internal data. Note that no copy of the input data is
   // made so the data owner needs to keep the data valid and unchanged for
-  // runtime of the decoder.
-  decode_buffer.Init(reinterpret_cast<const char *>(&vec_data[0]), compressed_data_size);
+  // runtime of the decoder. `compressed` outlives this call, so point directly
+  // at its buffer instead of copying it.
+  decode_buffer.Init(
+    reinterpret_cast<const char *>(compressed.compressed_data.data()), compressed_data_size);
 
   // create decoder object
   draco::Decoder decoder;

--- a/zlib_point_cloud_transport/src/zlib_cpp.cpp
+++ b/zlib_point_cloud_transport/src/zlib_cpp.cpp
@@ -98,7 +98,7 @@ std::list<std::shared_ptr<DataBlock>> Comp::Process(
   std::list<std::shared_ptr<DataBlock>> out_data_list;
   // Prepare output buffer memory.
   uint8_t out_buffer[MAX_CHUNK_SIZE];
-  zs_.next_in = reinterpret_cast<uint8_t *>(const_cast<uint8_t *>(buffer));
+  zs_.next_in = const_cast<uint8_t *>(buffer);
   zs_.avail_in = static_cast<uInt>(size);
   do {
     // Reset output buffer position and size.
@@ -128,6 +128,11 @@ Decomp::Decomp()
 
 Decomp::~Decomp() {inflateEnd(&zs_);}
 
+bool Decomp::IsSucc() const
+{
+  return init_ok_;
+}
+
 std::list<std::shared_ptr<DataBlock>> Decomp::Process(
   const std::shared_ptr<DataBlock> & compressed_data)
 {
@@ -146,11 +151,11 @@ std::list<std::shared_ptr<DataBlock>> Decomp::Process(
     switch (ret) {
       case Z_NEED_DICT:
         // Incoming data is invalid.
-        return std::move(out_data_list);
+        return out_data_list;
       case Z_DATA_ERROR:
       case Z_MEM_ERROR:
         // Critical error.
-        return std::move(out_data_list);
+        return out_data_list;
     }
     // Outcome size.
     std::size_t out_size = MAX_CHUNK_SIZE - zs_.avail_out;
@@ -159,7 +164,7 @@ std::list<std::shared_ptr<DataBlock>> Decomp::Process(
     memcpy(out_data->ptr, out_buffer, out_size);
     out_data_list.push_back(std::move(out_data));
   } while (zs_.avail_out == 0);
-  return std::move(out_data_list);
+  return out_data_list;
 }
 
 }  // namespace zlib

--- a/zlib_point_cloud_transport/src/zlib_cpp.hpp
+++ b/zlib_point_cloud_transport/src/zlib_cpp.hpp
@@ -99,6 +99,9 @@ public:
   /// Destructor, will release z_stream.
   ~Decomp();
 
+  /// Returns true if decompressor initialize successfully.
+  bool IsSucc() const;
+
   /// Decompress incoming buffer to DataBlock list.
   std::list<std::shared_ptr<DataBlock>> Process(
     const std::shared_ptr<DataBlock> & compressed_data);

--- a/zlib_point_cloud_transport/src/zlib_publisher.cpp
+++ b/zlib_point_cloud_transport/src/zlib_publisher.cpp
@@ -83,8 +83,12 @@ ZlibPublisher::TypedEncodeResult ZlibPublisher::encodeTyped(
   const sensor_msgs::msg::PointCloud2 & raw) const
 {
   zlib::Comp comp(static_cast<zlib::Comp::Level>(this->encode_level_), true);
+  if (!comp.IsSucc()) {
+    return tl::make_unexpected("Zlib compressor failed to initialize.");
+  }
+
   auto g_compressed_data =
-    comp.Process(&raw.data[0], raw.data.size(), true);
+    comp.Process(raw.data.data(), raw.data.size(), true);
 
   point_cloud_interfaces::msg::CompressedPointCloud2 compressed;
 
@@ -97,7 +101,7 @@ ZlibPublisher::TypedEncodeResult ZlibPublisher::encodeTyped(
 
   size_t index = 0;
   for (const auto & data : g_compressed_data) {
-    memcpy(&compressed.compressed_data[index], data->ptr, data->size);
+    memcpy(compressed.compressed_data.data() + index, data->ptr, data->size);
     index += data->size;
   }
 

--- a/zlib_point_cloud_transport/src/zlib_subscriber.cpp
+++ b/zlib_point_cloud_transport/src/zlib_subscriber.cpp
@@ -49,12 +49,19 @@ void ZlibSubscriber::declareParameters()
 ZlibSubscriber::DecodeResult ZlibSubscriber::decodeTyped(
   const point_cloud_interfaces::msg::CompressedPointCloud2 & msg) const
 {
+  if (msg.compressed_data.empty()) {
+    return tl::make_unexpected("Received compressed Zlib message with zero length.");
+  }
+
   auto result = std::make_shared<sensor_msgs::msg::PointCloud2>();
 
   zlib::Decomp decomp;
+  if (!decomp.IsSucc()) {
+    return tl::make_unexpected("Zlib decompressor failed to initialize.");
+  }
 
   std::shared_ptr<zlib::DataBlock> data = zlib::AllocateData(msg.compressed_data.size());
-  memcpy(data->ptr, &msg.compressed_data[0], msg.compressed_data.size());
+  memcpy(data->ptr, msg.compressed_data.data(), msg.compressed_data.size());
 
   std::list<std::shared_ptr<zlib::DataBlock>> out_data_list;
   out_data_list = decomp.Process(data);
@@ -62,7 +69,7 @@ ZlibSubscriber::DecodeResult ZlibSubscriber::decodeTyped(
   std::shared_ptr<zlib::DataBlock> data2 = zlib::ExpandDataList(out_data_list);
 
   result->data.resize(data2->size);
-  memcpy(&result->data[0], data2->ptr, data2->size);
+  memcpy(result->data.data(), data2->ptr, data2->size);
 
   result->width = msg.width;
   result->height = msg.height;

--- a/zstd_point_cloud_transport/include/zstd_point_cloud_transport/zstd_publisher.hpp
+++ b/zstd_point_cloud_transport/include/zstd_point_cloud_transport/zstd_publisher.hpp
@@ -53,8 +53,6 @@ class ZstdPublisher
     point_cloud_interfaces::msg::CompressedPointCloud2>
 {
 public:
-  ZstdPublisher();
-
   void declareParameters(const std::string & base_topic) override;
 
   std::string getDataType() const override;
@@ -62,13 +60,18 @@ public:
   TypedEncodeResult encodeTyped(const sensor_msgs::msg::PointCloud2 & raw) const override;
 
 private:
+  // Custom deleter so the ZSTD compression context is released via RAII.
+  struct CCtxDeleter
+  {
+    void operator()(ZSTD_CCtx * ctx) const noexcept {ZSTD_freeCCtx(ctx);}
+  };
+
   int encode_level_{7};
 
-  // When compressing many times,
-  // it is recommended to allocate a context just once,
-  // and re-use it for each successive compression operation.
-  // This will make workload friendlier for system's memory.
-  ZSTD_CCtx * zstd_context_{nullptr};
+  // When compressing many times, it is recommended to allocate a context just
+  // once and re-use it for each successive compression operation. The
+  // unique_ptr guarantees the context is freed when the publisher is destroyed.
+  std::unique_ptr<ZSTD_CCtx, CCtxDeleter> zstd_context_{ZSTD_createCCtx()};
 };
 }  // namespace zstd_point_cloud_transport
 

--- a/zstd_point_cloud_transport/include/zstd_point_cloud_transport/zstd_subscriber.hpp
+++ b/zstd_point_cloud_transport/include/zstd_point_cloud_transport/zstd_subscriber.hpp
@@ -34,6 +34,7 @@
 
 #include <zstd.h>
 
+#include <memory>
 #include <string>
 
 #include <point_cloud_interfaces/msg/compressed_point_cloud2.hpp>
@@ -49,8 +50,6 @@ class ZstdSubscriber
     point_cloud_interfaces::msg::CompressedPointCloud2>
 {
 public:
-  ZstdSubscriber();
-
   void declareParameters() override;
 
   std::string getDataType() const override;
@@ -59,7 +58,13 @@ public:
   const override;
 
 private:
-  ZSTD_DCtx * zstd_context_{nullptr};
+  // Custom deleter so the ZSTD decompression context is released via RAII.
+  struct DCtxDeleter
+  {
+    void operator()(ZSTD_DCtx * ctx) const noexcept {ZSTD_freeDCtx(ctx);}
+  };
+
+  std::unique_ptr<ZSTD_DCtx, DCtxDeleter> zstd_context_{ZSTD_createDCtx()};
 };
 }  // namespace zstd_point_cloud_transport
 

--- a/zstd_point_cloud_transport/src/zstd_publisher.cpp
+++ b/zstd_point_cloud_transport/src/zstd_publisher.cpp
@@ -41,11 +41,6 @@
 namespace zstd_point_cloud_transport
 {
 
-ZstdPublisher::ZstdPublisher()
-{
-  this->zstd_context_ = ZSTD_createCCtx();
-}
-
 void ZstdPublisher::declareParameters(const std::string & base_topic)
 {
   rcl_interfaces::msg::ParameterDescriptor encode_level_paramDescriptor;
@@ -92,19 +87,23 @@ std::string ZstdPublisher::getDataType() const
 ZstdPublisher::TypedEncodeResult ZstdPublisher::encodeTyped(
   const sensor_msgs::msg::PointCloud2 & raw) const
 {
-  size_t est_compress_size = ZSTD_compressBound(raw.data.size());
+  const size_t est_compress_size = ZSTD_compressBound(raw.data.size());
 
   point_cloud_interfaces::msg::CompressedPointCloud2 compressed;
   compressed.compressed_data.resize(est_compress_size);
 
-  auto compress_size =
-    ZSTD_compressCCtx(
-    this->zstd_context_,
-    static_cast<void *>(&compressed.compressed_data[0]),
+  const size_t compress_size = ZSTD_compressCCtx(
+    this->zstd_context_.get(),
+    compressed.compressed_data.data(),
     est_compress_size,
-    &raw.data[0],
+    raw.data.data(),
     raw.data.size(),
     this->encode_level_);
+
+  if (ZSTD_isError(compress_size)) {
+    return tl::make_unexpected(
+      std::string("Zstd compression failed: ") + ZSTD_getErrorName(compress_size));
+  }
 
   compressed.compressed_data.resize(compress_size);
 

--- a/zstd_point_cloud_transport/src/zstd_subscriber.cpp
+++ b/zstd_point_cloud_transport/src/zstd_subscriber.cpp
@@ -31,6 +31,7 @@
 
 #include <zstd.h>
 
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <string>
@@ -58,7 +59,7 @@ ZstdSubscriber::DecodeResult ZstdSubscriber::decodeTyped(
     return tl::make_unexpected("Received compressed Zstd message with zero length.");
   }
 
-  const unsigned long long est_decomp_size = ZSTD_getFrameContentSize(
+  const uint64_t est_decomp_size = ZSTD_getFrameContentSize(
     msg.compressed_data.data(), msg.compressed_data.size());
 
   if (est_decomp_size == ZSTD_CONTENTSIZE_ERROR) {

--- a/zstd_point_cloud_transport/src/zstd_subscriber.cpp
+++ b/zstd_point_cloud_transport/src/zstd_subscriber.cpp
@@ -42,11 +42,6 @@
 
 namespace zstd_point_cloud_transport
 {
-ZstdSubscriber::ZstdSubscriber()
-{
-  this->zstd_context_ = ZSTD_createDCtx();
-}
-
 void ZstdSubscriber::declareParameters()
 {
 }
@@ -59,19 +54,35 @@ std::string ZstdSubscriber::getDataType() const
 ZstdSubscriber::DecodeResult ZstdSubscriber::decodeTyped(
   const point_cloud_interfaces::msg::CompressedPointCloud2 & msg) const
 {
+  if (msg.compressed_data.empty()) {
+    return tl::make_unexpected("Received compressed Zstd message with zero length.");
+  }
+
+  const unsigned long long est_decomp_size = ZSTD_getFrameContentSize(
+    msg.compressed_data.data(), msg.compressed_data.size());
+
+  if (est_decomp_size == ZSTD_CONTENTSIZE_ERROR) {
+    return tl::make_unexpected("Zstd: input is not a valid compressed frame.");
+  }
+  if (est_decomp_size == ZSTD_CONTENTSIZE_UNKNOWN) {
+    return tl::make_unexpected(
+      "Zstd: decompressed size is unknown; streaming frames are not supported.");
+  }
+
   auto result = std::make_shared<sensor_msgs::msg::PointCloud2>();
-
-  auto const est_decomp_size =
-    ZSTD_getFrameContentSize(&msg.compressed_data[0], msg.compressed_data.size());
-
   result->data.resize(est_decomp_size);
 
-  size_t const decomp_size = ZSTD_decompressDCtx(
-    this->zstd_context_,
-    static_cast<void *>(&result->data[0]),
+  const size_t decomp_size = ZSTD_decompressDCtx(
+    this->zstd_context_.get(),
+    result->data.data(),
     est_decomp_size,
-    &msg.compressed_data[0],
+    msg.compressed_data.data(),
     msg.compressed_data.size());
+
+  if (ZSTD_isError(decomp_size)) {
+    return tl::make_unexpected(
+      std::string("Zstd decompression failed: ") + ZSTD_getErrorName(decomp_size));
+  }
 
   result->data.resize(decomp_size);
 


### PR DESCRIPTION
 - Replace undefined behaviour &vector[0] with data() 
 - copy/move cleanups
 - more validations

Claude Opus 4.7